### PR TITLE
Add useScript hook and example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+.pnpm-debug.log

--- a/examples/use-script/next-env.d.ts
+++ b/examples/use-script/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/use-script/package.json
+++ b/examples/use-script/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@maggo/use-flow": "workspace:*",
+    "@onflow/fcl": "^1.1.0",
+    "next": "12.1.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "18.0.0",
+    "@types/react": "^18.0.14",
+    "@types/react-dom": "^18.0.5",
+    "typescript": "4.7.4"
+  }
+}

--- a/examples/use-script/package.json
+++ b/examples/use-script/package.json
@@ -9,12 +9,12 @@
   "dependencies": {
     "@maggo/use-flow": "workspace:*",
     "@onflow/fcl": "^1.1.0",
-    "next": "12.1.6",
+    "next": "12.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "18.0.0",
+    "@types/node": "18.6.5",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "typescript": "4.7.4"

--- a/examples/use-script/pages/index.tsx
+++ b/examples/use-script/pages/index.tsx
@@ -5,11 +5,12 @@ const client = createClient({
   fclConfig: {
     "accessNode.api": "https://rest-mainnet.onflow.org",
     "discovery.wallet": "https://fcl-discovery.onflow.org/authn",
+    "0xFIND": "0x097bafa4e0b48eef",
   },
 });
 
 const CADENCE_SCRIPT = `
-import FIND, Profile from 0x097bafa4e0b48eef
+import FIND, Profile from 0xFIND
 
 pub fun main(name: String): Profile.UserProfile? {
   return FIND.lookup(name)?.asProfile()
@@ -34,12 +35,11 @@ export default function Home() {
 function FindProfile() {
   const [query, setQuery] = useState("marco.find");
 
-  const { data, isLoading, isFetching, isError, error, refetch } =
-    useScript<Profile>({
-      key: ["find-profile", query],
-      cadence: CADENCE_SCRIPT,
-      args: (arg, t) => [arg(prepareName(query), t.String)],
-    });
+  const { data, isLoading, isFetching, isError, error } = useScript<Profile>({
+    key: ["find-profile", query],
+    cadence: CADENCE_SCRIPT,
+    args: (arg, t) => [arg(prepareName(query), t.String)],
+  });
 
   const SearchHeader = (
     <form

--- a/examples/use-script/pages/index.tsx
+++ b/examples/use-script/pages/index.tsx
@@ -36,7 +36,6 @@ function FindProfile() {
   const [query, setQuery] = useState("marco.find");
 
   const { data, isLoading, isFetching, isError, error } = useScript<Profile>({
-    key: ["find-profile", query],
     cadence: CADENCE_SCRIPT,
     args: (arg, t) => [arg(prepareName(query), t.String)],
   });

--- a/examples/use-script/pages/index.tsx
+++ b/examples/use-script/pages/index.tsx
@@ -1,10 +1,14 @@
-import { createClient, FlowProvider, useScript } from "@maggo/use-flow";
+import {
+  createClient,
+  FlowProvider,
+  networks,
+  useScript,
+} from "@maggo/use-flow";
 import { useState } from "react";
 
 const client = createClient({
   fclConfig: {
-    "accessNode.api": "https://rest-mainnet.onflow.org",
-    "discovery.wallet": "https://fcl-discovery.onflow.org/authn",
+    ...networks.mainnet,
     "0xFIND": "0x097bafa4e0b48eef",
   },
 });

--- a/examples/use-script/pages/index.tsx
+++ b/examples/use-script/pages/index.tsx
@@ -1,0 +1,112 @@
+import { createClient, FlowProvider, useScript } from "@maggo/use-flow";
+import { useState } from "react";
+
+const client = createClient({
+  fclConfig: {
+    "accessNode.api": "https://rest-mainnet.onflow.org",
+    "discovery.wallet": "https://fcl-discovery.onflow.org/authn",
+  },
+});
+
+const CADENCE_SCRIPT = `
+import FIND, Profile from 0x097bafa4e0b48eef
+
+pub fun main(name: String): Profile.UserProfile? {
+  return FIND.lookup(name)?.asProfile()
+}
+`;
+
+interface Profile {
+  address: string;
+  name: string;
+  avatar: string;
+}
+
+export default function Home() {
+  return (
+    <FlowProvider client={client}>
+      <h1>useScript Example</h1>
+      <FindProfile />
+    </FlowProvider>
+  );
+}
+
+function FindProfile() {
+  const [query, setQuery] = useState("marco.find");
+
+  const { data, isLoading, isFetching, isError, error, refetch } =
+    useScript<Profile>({
+      key: ["find-profile", query],
+      cadence: CADENCE_SCRIPT,
+      args: (arg, t) => [arg(prepareName(query), t.String)],
+    });
+
+  const SearchHeader = (
+    <form
+      style={{ display: "flex", gap: ".5rem", alignItems: "center" }}
+      onSubmit={(e) => {
+        e.preventDefault();
+        const el = e.currentTarget.elements.namedItem(
+          "query"
+        ) as HTMLInputElement;
+        setQuery(el.value);
+      }}
+    >
+      <input type="search" name="query" defaultValue={query} />
+      <button type="submit">Submit</button>
+      {isFetching && <span>Fetching…</span>}
+    </form>
+  );
+
+  if (isLoading) {
+    return (
+      <>
+        {SearchHeader}
+        <p>Loading…</p>
+      </>
+    );
+  }
+
+  if (isError) {
+    return (
+      <>
+        {SearchHeader}
+        <p>Internal Error: {error.internalMessage}</p>
+        <details>
+          <summary>Raw Error</summary>
+          <pre style={{ overflowX: "auto" }}>{error.message}</pre>
+        </details>
+      </>
+    );
+  }
+
+  if (!data) {
+    return (
+      <>
+        {SearchHeader}
+        <p>No profile found</p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {SearchHeader}
+      <br />
+      <img src={data.avatar} alt="" width={120} height={120} />
+      <h2>{data.name}</h2>
+      <p>{data.address}</p>
+      <details>
+        <summary>Raw Data</summary>
+        <pre style={{ overflowX: "auto" }}>{JSON.stringify(data, null, 2)}</pre>
+      </details>
+    </>
+  );
+}
+
+/**
+ * Remove the .find prefix for lookup
+ */
+function prepareName(name: string): string {
+  return name.toLowerCase().replace(/\.find$/g, "");
+}

--- a/examples/use-script/tsconfig.json
+++ b/examples/use-script/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
   },
   "peerDependencies": {
     "@onflow/fcl": "^1.2.0",
+    "@onflow/types": "^1.0.2",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "tsup --watch"
   },
   "keywords": [
     "flow",

--- a/packages/core/src/FlowProvider.tsx
+++ b/packages/core/src/FlowProvider.tsx
@@ -19,11 +19,10 @@ interface FlowProviderProps {
 }
 
 export function FlowProvider({ children, client }: FlowProviderProps) {
-  React.useEffect(() => {
-    const c = config();
-    Object.entries(client.fclConfig).forEach(([key, value]) => {
-      c.put(key, value);
-    });
+  // @TODO Investigate better way to apply config
+  // We want to be SSR friendly, so we can't use useEffect/useLayoutEffect
+  React.useLayoutEffect(() => {
+    config(client.fclConfig);
   }, [client.fclConfig]);
 
   return (

--- a/packages/core/src/FlowProvider.tsx
+++ b/packages/core/src/FlowProvider.tsx
@@ -1,8 +1,9 @@
 import { config } from "@onflow/fcl";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
+import { AddressLike } from "./misc";
 
-export interface FCLConfig {
+export interface FCLConfig extends Record<AddressLike, AddressLike> {
   "accessNode.api": string;
   "app.detail.title"?: string;
   "app.detail.icon"?: string;

--- a/packages/core/src/arguments.ts
+++ b/packages/core/src/arguments.ts
@@ -1,0 +1,3 @@
+// @TODO: Refactor to better argument type system */
+export type Argument = [any, any];
+export type ArgumentFunction = (arg: Function, t: any) => Argument[];

--- a/packages/core/src/arguments.ts
+++ b/packages/core/src/arguments.ts
@@ -1,3 +1,52 @@
-// @TODO: Refactor to better argument type system */
-export type Argument = [any, any];
-export type ArgumentFunction = (arg: Function, t: any) => Argument[];
+/** @TODO Refactor to better argument type system */
+
+export type ArgumentFunction = (arg: ArgFunc, t: FType) => any[];
+
+type ArgFunc<
+  T extends any = any,
+  F extends FType<T>[keyof FType] = FType<T>[keyof FType]
+> = (value: T, xform: F) => ArgumentObject<T, F>;
+
+type ArgType<T extends any = any> = (
+  label: string,
+  asArgument: (value: T) => any
+) => { label: string; asArgument: (value: T) => any };
+
+type ArgumentObject<Value extends any, Form extends FType[keyof FType]> = {
+  value: Value;
+  xform: Form;
+};
+
+interface FType<T extends any = any> {
+  UInt: ArgType<string>;
+  Int: ArgType<string>;
+  UInt8: ArgType<string>;
+  Int8: ArgType<string>;
+  UInt16: ArgType<string>;
+  Int16: ArgType<string>;
+  UInt32: ArgType<string>;
+  Int32: ArgType<string>;
+  UInt64: ArgType<string>;
+  Int64: ArgType<string>;
+  UInt128: ArgType<string>;
+  Int128: ArgType<string>;
+  UInt256: ArgType<string>;
+  Int256: ArgType<string>;
+  Word8: ArgType<string>;
+  Word16: ArgType<string>;
+  Word32: ArgType<string>;
+  Word64: ArgType<string>;
+  UFix64: ArgType<string>;
+  Fix64: ArgType<string>;
+  String: ArgType<string>;
+  Character: ArgType<string>;
+  Bool: ArgType<boolean>;
+  Address: ArgType<string>;
+  Optional: (value: ArgType<T>) => ArgType<T>;
+  Array: (value: ArgType<T>) => ArgType<T>;
+  Dictionary: (value: { key: ArgType; value: ArgType }) => ArgType;
+  Path: (value: {
+    domain: "public" | "private" | "storage";
+    identifier: string;
+  }) => ArgType<string>;
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,11 @@
+export class FlowError extends Error {
+  public kind?: string;
+  public internalMessage?: string;
+
+  constructor(message: string, kind?: string, internalMessage?: string) {
+    super(message);
+
+    this.kind = kind;
+    this.internalMessage = internalMessage;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,5 @@ export { createClient, FlowProvider } from "./FlowProvider";
 export * as networks from "./networks";
 export { useAuthentication } from "./useAuthentication";
 export { useScript } from "./useScript";
+
+export { ArgumentFunction } from "./arguments";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export { createClient, FlowProvider } from "./FlowProvider";
 export * as networks from "./networks";
 export { useAuthentication } from "./useAuthentication";
+export { useScript } from "./useScript";

--- a/packages/core/src/misc.ts
+++ b/packages/core/src/misc.ts
@@ -1,0 +1,1 @@
+export type AddressLike = `0x${string}`;

--- a/packages/core/src/modules.d.ts
+++ b/packages/core/src/modules.d.ts
@@ -1,1 +1,2 @@
 declare module "@onflow/fcl";
+declare module "@onflow/types";

--- a/packages/core/src/useScript.tsx
+++ b/packages/core/src/useScript.tsx
@@ -1,15 +1,13 @@
 import { query } from "@onflow/fcl";
-import { QueryKey, useQuery, UseQueryOptions } from "@tanstack/react-query";
+import * as types from "@onflow/types";
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { ArgumentFunction } from "./arguments";
 import { FlowError } from "./errors";
 
+// @TODO Replace with @onflow/sdk arg function
+const arg = (value: any, xform: any) => ({ value, xform });
+
 interface UseScriptProps<Result = any> {
-  /**
-   * The key is a string or array that identifies your query in the cache.
-   *
-   * @see {@link https://react-query.tanstack.com/guides/query-keys}
-   */
-  key: QueryKey;
   /**
    * The cadence code of your script
    */
@@ -43,11 +41,12 @@ export function useScript<ResultType = any>({
   cadence,
   args,
   limit,
-  key,
   options,
 }: UseScriptProps) {
+  const resolvedArgs = args(arg, types);
+
   const result = useQuery<ResultType, FlowError>(
-    key,
+    [cadence, resolvedArgs],
     () => executeScript<ResultType>({ cadence, args, limit }),
     options
   );

--- a/packages/core/src/useScript.tsx
+++ b/packages/core/src/useScript.tsx
@@ -1,71 +1,76 @@
 import { query } from "@onflow/fcl";
 import { QueryKey, useQuery, UseQueryOptions } from "@tanstack/react-query";
-
-// @TODO: Refactor to better argument type system */
-type Argument = [any, any];
-type ArgumentFunction = (arg: Function, t: any) => Argument[];
-
-class FlowError extends Error {
-  public kind?: string;
-  public internalMessage?: string;
-
-  constructor(message: string, kind?: string, internalMessage?: string) {
-    super(message);
-
-    this.kind = kind;
-    this.internalMessage = internalMessage;
-  }
-}
+import { ArgumentFunction } from "./arguments";
+import { FlowError } from "./errors";
 
 interface UseScriptProps<Result = any> {
   /**
    * The key is a string or array that identifies your query in the cache.
    *
-   * @see https://react-query.tanstack.com/guides/query-keys
+   * @see {@link https://react-query.tanstack.com/guides/query-keys}
    */
   key: QueryKey;
-  /** The cadence code of your script */
+  /**
+   * The cadence code of your script
+   */
   cadence: string;
   /**
    * The arguments that are passed to your script in argument function form.
    *
-   * @see https://docs.onflow.org/fcl/reference/api/#argumentfunction
+   * @see {@link https://docs.onflow.org/fcl/reference/api/#argumentfunction}
    */
   args?: ArgumentFunction;
   /**
+   * Optional gas limit for this script.
+   *
+   * @see {@link https://docs.onflow.org/fcl/reference/api/#options}
+   */
+  limit?: number;
+  /**
    * Optional react-query options
    *
-   * @see https://react-query.tanstack.com/reference/useQuery
+   * @see {@link https://react-query.tanstack.com/reference/useQuery}
    */
   options?: Omit<UseQueryOptions<Result, FlowError>, "queryKey" | "queryFn">;
 }
 
+/**
+ * This hook provides an abstraction of the FCL `query` functionality.
+ *
+ * @see {@link https://docs.onflow.org/fcl/reference/api/#query}
+ */
 export function useScript<ResultType = any>({
   cadence,
   args,
+  limit,
   key,
   options,
 }: UseScriptProps) {
   const result = useQuery<ResultType, FlowError>(
     key,
-    () => executeScript<ResultType>({ cadence, args }),
+    () => executeScript<ResultType>({ cadence, args, limit }),
     options
   );
 
   return result;
 }
 
+interface ExecuteScriptProps {
+  cadence: string;
+  args: ArgumentFunction;
+  limit?: number;
+}
+
 export async function executeScript<ResultType = any>({
   cadence,
   args,
-}: {
-  cadence: string;
-  args: ArgumentFunction;
-}): Promise<ResultType> {
+  limit,
+}: ExecuteScriptProps): Promise<ResultType> {
   try {
     return await query({
       cadence,
       args,
+      limit,
     });
   } catch (e: any) {
     if (e.message) {

--- a/packages/core/src/useScript.tsx
+++ b/packages/core/src/useScript.tsx
@@ -1,0 +1,83 @@
+import { query } from "@onflow/fcl";
+import { QueryKey, useQuery, UseQueryOptions } from "@tanstack/react-query";
+
+// @TODO: Refactor to better argument type system */
+type Argument = [any, any];
+type ArgumentFunction = (arg: Function, t: any) => Argument[];
+
+class FlowError extends Error {
+  public kind?: string;
+  public internalMessage?: string;
+
+  constructor(message: string, kind?: string, internalMessage?: string) {
+    super(message);
+
+    this.kind = kind;
+    this.internalMessage = internalMessage;
+  }
+}
+
+interface UseScriptProps<Result = any> {
+  /**
+   * The key is a string or array that identifies your query in the cache.
+   *
+   * @see https://react-query.tanstack.com/guides/query-keys
+   */
+  key: QueryKey;
+  /** The cadence code of your script */
+  cadence: string;
+  /**
+   * The arguments that are passed to your script in argument function form.
+   *
+   * @see https://docs.onflow.org/fcl/reference/api/#argumentfunction
+   */
+  args?: ArgumentFunction;
+  /**
+   * Optional react-query options
+   *
+   * @see https://react-query.tanstack.com/reference/useQuery
+   */
+  options?: Omit<UseQueryOptions<Result, FlowError>, "queryKey" | "queryFn">;
+}
+
+export function useScript<ResultType = any>({
+  cadence,
+  args,
+  key,
+  options,
+}: UseScriptProps) {
+  const result = useQuery<ResultType, FlowError>(
+    key,
+    () => executeScript<ResultType>({ cadence, args }),
+    options
+  );
+
+  return result;
+}
+
+export async function executeScript<ResultType = any>({
+  cadence,
+  args,
+}: {
+  cadence: string;
+  args: ArgumentFunction;
+}): Promise<ResultType> {
+  try {
+    return await query({
+      cadence,
+      args,
+    });
+  } catch (e: any) {
+    if (e.message) {
+      // @TODO: Implement custom error system */
+      const matches = (e.message as string).match(/^error: (.*): (.*)$/m);
+      if (!matches) throw e;
+
+      const [, kind, internalMessage] = matches;
+
+      throw new FlowError(e.message, kind, internalMessage);
+    }
+
+    throw new FlowError(e.message);
+  }
+}

--- a/packages/core/src/useScript.tsx
+++ b/packages/core/src/useScript.tsx
@@ -60,6 +60,9 @@ interface ExecuteScriptProps {
   limit?: number;
 }
 
+/**
+ * Helper function that wraps the FCL `query` function and adds custom error handling.
+ */
 export async function executeScript<ResultType = any>({
   cadence,
   args,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,29 @@ importers:
       '@types/react-dom': 18.0.6
       typescript: 4.7.4
 
+  examples/use-script:
+    specifiers:
+      '@maggo/use-flow': workspace:*
+      '@onflow/fcl': ^1.1.0
+      '@types/node': 18.0.0
+      '@types/react': ^18.0.14
+      '@types/react-dom': ^18.0.5
+      next: 12.1.6
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      typescript: 4.7.4
+    dependencies:
+      '@maggo/use-flow': link:../../packages/core
+      '@onflow/fcl': 1.1.0
+      next: 12.1.6_biqbaboplfbrettd7655fr4n2y
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@types/node': 18.0.0
+      '@types/react': 18.0.14
+      '@types/react-dom': 18.0.5
+      typescript: 4.7.4
+
   packages/core:
     specifiers:
       '@onflow/fcl': ^1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,28 +32,29 @@ importers:
     specifiers:
       '@maggo/use-flow': workspace:*
       '@onflow/fcl': ^1.1.0
-      '@types/node': 18.0.0
+      '@types/node': 18.6.5
       '@types/react': ^18.0.14
       '@types/react-dom': ^18.0.5
-      next: 12.1.6
+      next: 12.2.4
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: 4.7.4
     dependencies:
       '@maggo/use-flow': link:../../packages/core
-      '@onflow/fcl': 1.1.0
-      next: 12.1.6_biqbaboplfbrettd7655fr4n2y
+      '@onflow/fcl': 1.2.0
+      next: 12.2.4_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
-      '@types/node': 18.0.0
-      '@types/react': 18.0.14
-      '@types/react-dom': 18.0.5
+      '@types/node': 18.6.5
+      '@types/react': 18.0.17
+      '@types/react-dom': 18.0.6
       typescript: 4.7.4
 
   packages/core:
     specifiers:
       '@onflow/fcl': ^1.2.0
+      '@onflow/types': ^1.0.2
       '@tanstack/react-query': ^4.0.10
       '@types/node': 18.6.5
       '@types/react': ^18.0.17
@@ -65,6 +66,7 @@ importers:
       typescript: ^4.7.4
     dependencies:
       '@onflow/fcl': 1.2.0
+      '@onflow/types': 1.0.3
       '@tanstack/react-query': 4.0.10_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       '@types/node': 18.6.5


### PR DESCRIPTION
This adds a hook to abstract FCLs query function. 
The user passes cadence code, arguments in function form and a query key as parameters.

## Todos

- [x] ~~Refactor custom error handling~~ Follow-up: https://github.com/maggo/use-flow/issues/6
- [x] ~~Add typing to arguments function~~ Follow-up: https://github.com/maggo/use-flow/issues/7
- [x] Further examples