### PR TITLE
feat: Add default network configs

### DIFF
--- a/examples/use-authentication/pages/index.tsx
+++ b/examples/use-authentication/pages/index.tsx
@@ -1,9 +1,13 @@
-import { FlowProvider, createClient, useAuthentication } from "@maggo/use-flow";
+import {
+  createClient,
+  FlowProvider,
+  networks,
+  useAuthentication,
+} from "@maggo/use-flow";
 
 const client = createClient({
   fclConfig: {
-    "accessNode.api": "https://access-testnet.onflow.org",
-    "discovery.wallet": "https://fcl-discovery.onflow.org/testnet/authn",
+    ...networks.testnet,
   },
 });
 

--- a/flow.json
+++ b/flow.json
@@ -1,0 +1,16 @@
+{
+  "contracts": {},
+  "networks": {
+    "emulator": "127.0.0.1:3569",
+    "mainnet": "access.mainnet.nodes.onflow.org:9000",
+    "testnet": "access.devnet.nodes.onflow.org:9000",
+    "canarynet": "access.canary.nodes.onflow.org:9000"
+  },
+  "accounts": {
+    "emulator-account": {
+      "address": "f8d6e0586b0a20c7",
+      "key": "aebb225a57e8f92eb83b81a48b6c07f5d1ecc0ee6d913c84fa93f60d8a5c68f8"
+    }
+  },
+  "deployments": {}
+}

--- a/packages/core/src/FlowProvider.tsx
+++ b/packages/core/src/FlowProvider.tsx
@@ -2,7 +2,7 @@ import { config } from "@onflow/fcl";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
-interface FCLConfig {
+export interface FCLConfig {
   "accessNode.api": string;
   "app.detail.title"?: string;
   "app.detail.icon"?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export { createClient, FlowProvider } from "./FlowProvider";
+export * as networks from "./networks";
 export { useAuthentication } from "./useAuthentication";

--- a/packages/core/src/networks.ts
+++ b/packages/core/src/networks.ts
@@ -1,0 +1,39 @@
+import { FCLConfig } from "./FlowProvider";
+
+/**
+ * Default access node and wallet discovery config for mainnet
+ */
+export const mainnet: FCLConfig = {
+  "accessNode.api": "https://rest-mainnet.onflow.org",
+  "discovery.wallet": "https://fcl-discovery.onflow.org/testnet/authn",
+  "flow.network": "mainnet",
+};
+
+/**
+ * Default access node and wallet discovery config for testnet
+ */
+export const testnet: FCLConfig = {
+  "accessNode.api": "https://rest-testnet.onflow.org",
+  "discovery.wallet": "https://fcl-discovery.onflow.org/mainnet/authn",
+  "flow.network": "testnet",
+};
+
+/**
+ * Default access node and wallet discovery config for canarynet
+ */
+export const canarynet: FCLConfig = {
+  "accessNode.api": "https://rest-canarynet.onflow.org",
+  "discovery.wallet": "https://fcl-discovery.onflow.org/canarynet/authn",
+  "flow.network": "canarynet",
+};
+
+/**
+ * Default access node and wallet discovery config for local emulator network
+ *
+ * @warning Requires the flow emulator network and flow dev-wallet to be running
+ */
+export const local: FCLConfig = {
+  "accessNode.api": "http://localhost:8888",
+  "discovery.wallet": "http://localhost:8701/fcl/authn",
+  "flow.network": "local",
+};


### PR DESCRIPTION
This adds configs with common access node URLs that can be used as-is or extendend